### PR TITLE
Fix a bug with quotation marks in the caption field

### DIFF
--- a/plugins/Assetylene/lib/Assetylene/CMS.pm
+++ b/plugins/Assetylene/lib/Assetylene/CMS.pm
@@ -140,7 +140,7 @@ sub assetylene_insert_asset {
         # Parse JSON.
         my $prefs = $app->param('prefs_json');
         $prefs =~ s/^"|"$//g;
-        $prefs =~ s/\\//g;
+        $prefs =~ s/\\([\\"])/$1/g;
         $prefs = eval { MT::Util::from_json($prefs) };
         if ( !$prefs ) {
             return $app->errtrans('Invalid request.');


### PR DESCRIPTION
Hi,
https://app.asana.com/0/50308864538247/133180219856683/f
There is a bug when you want to use quotation marks in the caption field. I think it should resolve this. Can you take a look on this?
